### PR TITLE
Refactor main.dart and note_page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,52 +1,20 @@
-import 'constants.dart';
 import 'package:flutter/material.dart';
-import 'components/note_card.dart';
-import 'model/note.dart';
 import 'package:flutter_week2/controller/note_service.dart';
+import 'view/note_page.dart';
 
-void main() => runApp(MaterialApp(theme: ThemeData.dark(), home: MyApp()));
-
-class MyApp extends StatefulWidget {
-  MyApp({super.key});
-
-  @override
-  State<MyApp> createState() => _MyAppState();
+void main() {
+  final NoteService noteService = NoteService();
+  runApp(
+    MaterialApp(home: MyApp(noteService: noteService), theme: ThemeData.dark()),
+  );
 }
 
-class _MyAppState extends State<MyApp> {
+class MyApp extends StatelessWidget {
+  const MyApp({super.key, required this.noteService});
+  final NoteService noteService;
 
-  final NoteService noteService = NoteService();
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          showDialog(
-            context: context,
-            builder:
-                (BuildContext context) => AlertDialog(
-                  title: TextField(onChanged: (value) {}),
-                  content: TextField(onChanged: (value) {}),
-                ),
-          );
-        },
-        child: Icon(Icons.add),
-      ),
-      appBar: AppBar(title: const Text('Flutter Week 2')),
-      body: ListView.builder(
-        itemCount: noteService.notes.length,
-        itemBuilder: (context, index) {
-          return NoteCard(
-            note: noteService.notes[index],
-            color: colorPool[index % colorPool.length],
-            onPressed: () {
-              setState(() {
-                noteService.deleteNote(index:index);
-              });
-            },
-          );
-        },
-      ),
-    );
+    return NotePage(noteService: noteService);
   }
 }

--- a/lib/view/note_page.dart
+++ b/lib/view/note_page.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_week2/constants.dart';
+import 'package:flutter_week2/components/note_card.dart';
+import 'package:flutter_week2/controller/note_service.dart';
+import 'package:flutter/material.dart';
+
+class NotePage extends StatefulWidget {
+  const NotePage({super.key, required this.noteService});
+  final NoteService noteService;
+
+  @override
+  State<NotePage> createState() => _NotePageState();
+}
+
+class _NotePageState extends State<NotePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          showDialog(
+            context: context,
+            builder:
+                (BuildContext context) => AlertDialog(
+              title: TextField(onChanged: (value) {}),
+              content: TextField(onChanged: (value) {}),
+            ),
+          );
+        },
+        child: Icon(Icons.add),
+      ),
+      appBar: AppBar(title: const Text('Flutter Week 2')),
+      body: ListView.builder(
+        itemCount: widget.noteService.notes.length,
+        itemBuilder: (context, index) {
+          return NoteCard(
+            note: widget.noteService.notes[index],
+            color: colorPool[index % colorPool.length],
+            onPressed: () {
+              setState(() {
+                widget.noteService.deleteNote(index: index);
+              });
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -62,6 +70,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -147,6 +163,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -155,6 +179,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_staggered_grid_view: ^0.7.0
   intl: ^0.20.2
+  flutter_bloc: ^9.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request refactors the main application structure to improve modularity and maintainability by introducing a new `NotePage` widget and updating dependencies. The changes include moving UI logic to a dedicated file, converting the main widget to a `StatelessWidget`, and adding `flutter_bloc` as a new dependency.

### Refactor for modularity and maintainability:

* Extracted the UI logic for the note management screen into a new `NotePage` widget (`lib/view/note_page.dart`). This includes the `Scaffold` with the `FloatingActionButton`, `AppBar`, and the `ListView.builder` for displaying notes. (`[lib/view/note_page.dartR1-R48](diffhunk://#diff-0eaddcdb5194fc2e9eee425e088e1c61f3b8c264ce7a45340e296b2efbd3df37R1-R48)`)

* Updated `lib/main.dart`:
  - Replaced the inline UI logic with a call to the new `NotePage` widget.
  - Converted the `MyApp` class from a `StatefulWidget` to a `StatelessWidget` for simplicity, as it no longer manages state directly. (`[lib/main.dartL1-R18](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L1-R18)`)

### Dependency updates:

* Added `flutter_bloc` version `^9.1.1` to `pubspec.yaml` to support state management, potentially for future enhancements. (`[pubspec.yamlR39](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R39)`)